### PR TITLE
Improve pangram grep

### DIFF
--- a/assets/hole.js
+++ b/assets/hole.js
@@ -144,8 +144,17 @@ onload = function() {
         // Show args if we have 'em.
         if (data.Argv) {
             document.querySelector('#arg').style.display = 'block';
-            document.querySelector('#arg div').innerHTML
-                = '<span>' + data.Argv.join('</span> <span>') + '</span>';
+            const argDiv = document.querySelector('#arg div');
+            // Remove all arg spans
+            while (argDiv.firstChild) {
+                argDiv.removeChild(argDiv.firstChild);
+            }
+            // Add a span for each arg
+            for (const arg of data.Argv) {
+                argDiv.appendChild(document.createElement('span'));
+                argDiv.lastChild.innerText = arg;
+                argDiv.appendChild(document.createTextNode(' '));
+            }
         }
         else
             document.querySelector('#arg').style.display = '';

--- a/routes/pangram-grep.go
+++ b/routes/pangram-grep.go
@@ -1,27 +1,39 @@
 package routes
 
-import "math/rand"
+import (
+	"math/rand"
+	"strings"
+)
 
 func pangramGrep() (args []string, out string) {
 	// They all start lowercase and valid.
 	pangrams := [][]byte{
+		[]byte(`a large fawn jumped quickly over white zinc boxes.`),
 		[]byte(`all questions asked by five watched experts amaze the judge.`),
 		[]byte(`a quick movement of the enemy will jeopardize six gunboats.`),
 		[]byte(`back in june we delivered oxygen equipment of the same size.`),
 		[]byte(`battle of thermopylae: quick javelin grazed wry xerxes.`),
 		[]byte(`bored? craving a pub quiz fix? why, just come to the royal oak!`),
+		[]byte(`bprsjzfwdqyaxgckilvunthemo`),
+		[]byte(`brawny gods just flocked up to quiz and vex him.`),
 		[]byte(`cute, kind, jovial, foxy physique, amazing beauty? wowser!`),
+		[]byte(`fix problem quickly with galvanized jets.`),
 		[]byte(`foxy parsons quiz and cajole the lovably dim wiki-girl.`),
 		[]byte(`grumpy wizards make toxic brew for the evil queen and jack.`),
+		[]byte(`hey zach, should i program a hex editor in java? why not sql or brainf--k!`),
 		[]byte(`how razorback-jumping frogs can level six piqued gymnasts!`),
 		[]byte(`jackie will budget for the most expensive zoology equipment.`),
 		[]byte(`jack quietly moved up front and seized the big ball of wax.`),
 		[]byte(`jim quickly realized that the beautiful gowns are expensive.`),
 		[]byte(`just poets wax boldly as kings and queens march over fuzz.`),
+		[]byte(`my faxed joke won a pager in the cable tv quiz show.`),
 		[]byte(`quirky spud boys can jam after zapping five worthy polysixes.`),
 		[]byte(`sixty zips were quickly picked from the woven jute bag.`),
+		[]byte(`the quick brown fox jumps over the lazy dog.`),
 		[]byte(`the wizard quickly jinxed the gnomes before they vaporized.`),
+		[]byte(`when zombies arrive, quickly fax judge pat.`),
 		[]byte(`"who am taking the ebonics quiz?", the prof jovially axed.`),
+		[]byte(`zjxlwogki8yq2h04vf3crnpda5bstu791e6m!`),
 	}
 
 	// Shuffle the whole set.
@@ -30,36 +42,49 @@ func pangramGrep() (args []string, out string) {
 		pangrams[i], pangrams[j] = pangrams[j], pangrams[i]
 	}
 
+	for i, pangram := range pangrams {
+		clone := make([]byte, len(pangram))
+		copy(clone, pangram)
+
+		// Replace letter `i` with a different random letter.
+		old := 'a' + byte(i)
+		new := 'a' + byte((i+rand.Intn(25)+1)%26)
+		for j, letter := range clone {
+			if letter == old {
+				clone[j] = new
+			}
+		}
+
+		pangrams = append(pangrams, clone)
+	}
+
+	// Uppercase random letters.
 	for _, pangram := range pangrams {
-		valid := true
-
-		// Make invalid by inc-ing all occurrences of random letter.
-		if rand.Intn(2) == 0 {
-			// a - y
-			replace := 'a' + byte(rand.Intn(25))
-
-			for i, letter := range pangram {
-				if letter == replace {
-					pangram[i]++
-				}
-			}
-
-			valid = false
-		}
-
-		// Uppercase random letters.
-		for i, letter := range pangram {
+		for j, letter := range pangram {
 			if 'a' <= letter && letter <= 'z' && rand.Intn(2) == 0 {
-				pangram[i] -= 32
+				pangram[j] -= 32
 			}
 		}
+	}
 
+	// Shuffle the whole set.
+	for i := range pangrams {
+		j := rand.Intn(i + 1)
+		pangrams[i], pangrams[j] = pangrams[j], pangrams[i]
+	}
+
+outer:
+	for _, pangram := range pangrams {
 		str := string(pangram)
 		args = append(args, str)
 
-		if valid {
-			out += str + "\n"
+		for c := 'a'; c <= 'z'; c++ {
+			if !strings.ContainsRune(str, c) && !strings.ContainsRune(str, c-32) {
+				continue outer
+			}
 		}
+
+		out += str + "\n"
 	}
 
 	// Drop the trailing newline.

--- a/routes/pangram-grep.go
+++ b/routes/pangram-grep.go
@@ -8,6 +8,7 @@ import (
 func pangramGrep() (args []string, out string) {
 	// They all start lowercase and valid.
 	pangrams := [][]byte{
+		[]byte("6>_4\"gv9lb?2!ic7=-m'fd30ph].o%@w+[8unk&t1es<az(x;$^y#)q,rj\\5/*:"),
 		[]byte(`a large fawn jumped quickly over white zinc boxes.`),
 		[]byte(`all questions asked by five watched experts amaze the judge.`),
 		[]byte(`a quick movement of the enemy will jeopardize six gunboats.`),
@@ -33,7 +34,6 @@ func pangramGrep() (args []string, out string) {
 		[]byte(`the wizard quickly jinxed the gnomes before they vaporized.`),
 		[]byte(`when zombies arrive, quickly fax judge pat.`),
 		[]byte(`"who am taking the ebonics quiz?", the prof jovially axed.`),
-		[]byte(`zjxlwogki8yq2h04vf3crnpda5bstu791e6m!`),
 	}
 
 	// Shuffle the whole set.


### PR DESCRIPTION
Use a valid and an invalid version of each pangram. This should prevent solutions that pass sometimes by not considering some punctuation.