### PR TITLE
Show process exit reason as well as stderr

### DIFF
--- a/assets/hole.js
+++ b/assets/hole.js
@@ -162,7 +162,7 @@ onload = function() {
         // Show err if we have some and we're not passing.
         if (data.Err && !pass) {
             document.querySelector('#err').style.display = 'block';
-            document.querySelector('#err div').innerHTML = data.Err;
+            document.querySelector('#err div').innerHTML = data.Err.replace(/\n/g, '<br>');
         }
         else
             document.querySelector('#err').style.display = '';

--- a/routes/solution.go
+++ b/routes/solution.go
@@ -236,6 +236,7 @@ func runCode(hole, lang, code string, args []string) (string, string) {
 		if ctx.Err() == context.DeadlineExceeded {
 			stderr.WriteString("Killed for exceeding the 7s timeout.")
 		} else {
+			stderr.WriteString(err.Error())
 			println(err.Error())
 		}
 	}


### PR DESCRIPTION
For example:
```c
main(){exit(99);}
//<stdin>:1: warning: implicit declaration of function 'exit'
//exit status 99

main(){0/0;}
//signal: floating point exception

main(){*(int*)0=0;}
//signal: segmentation fault```