### PR TITLE
Define 'color' for #status

### DIFF
--- a/assets/hole.css
+++ b/assets/hole.css
@@ -230,6 +230,7 @@ main nav a:nth-child(3):before {
 
 #status {
     background: #fdd;
+    color: black;
     display: none;
     margin-top: 75px;
     padding: 10px;


### PR DESCRIPTION
If the browser default 'color' is bright (on a dark theme), the text was hardly readable.

![Screenshot](https://user-images.githubusercontent.com/8593614/58401962-784be900-805f-11e9-82e9-1468c75b1dba.png)
