### PR TITLE
Remove closing tag for PHP

### DIFF
--- a/routes/solution.go
+++ b/routes/solution.go
@@ -204,7 +204,7 @@ func runCode(hole, lang, code string, args []string, userID int) (string, string
 	var stderr, stdout bytes.Buffer
 
 	if lang == "php" {
-		code = "<?php " + code + " ?>"
+		code = "<?php " + code + " ;"
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)


### PR DESCRIPTION
This is primarily to prevent a quine solution that works by outputting the boilerplate (#106). Omitting the final closing tag on PHP-only scripts is generally recommended anyway (see: [PHP: PHP tags - Manual](https://www.php.net/manual/en/language.basic-syntax.phptags.php), [PHP: Instruction separation - Manual](https://www.php.net/basic-syntax.instruction-separation)). Instead, I have added a semi-colon to prevent invalidating all previous solutions.