### PR TITLE
Minor fix in sudoku solver

### DIFF
--- a/routes/sudoku.go
+++ b/routes/sudoku.go
@@ -61,7 +61,7 @@ Numbers:
 		}
 
 		// number is already in the block.
-		for _, row := range board[i0:i] {
+		for _, row := range board[i0 : i0+blockSize] {
 			for _, numberInRow := range row[j0 : j0+blockSize] {
 				if number == numberInRow {
 					continue Numbers


### PR DESCRIPTION
Not all rows of the 3x3-block are checked when validating the inserted number. Perhaps this code was copied from function `generate` where this behavior is correct.

As a result, function `solve` may incorrectly determine that board has several solutions.

Here is an example of such a board:
```
┏━━━┯━━━┯━━━┳━━━┯━━━┯━━━┳━━━┯━━━┯━━━┓
┃   │ 2 │ 3 ┃   │ 9 │ 7 ┃ 6 │ 4 │ 5 ┃
┠───┼───┼───╂───┼───┼───╂───┼───┼───┨
┃ 4 │ 5 │ 6 ┃ 2 │ 3 │ 1 ┃ 9 │ 7 │ 8 ┃
┠───┼───┼───╂───┼───┼───╂───┼───┼───┨
┃ 7 │ 8 │ 9 ┃ 5 │ 6 │ 4 ┃ 3 │ 1 │ 2 ┃
┣━━━┿━━━┿━━━╋━━━┿━━━┿━━━╋━━━┿━━━┿━━━┫
┃   │ 9 │ 7 ┃   │ 2 │ 3 ┃ 5 │ 6 │ 4 ┃
┠───┼───┼───╂───┼───┼───╂───┼───┼───┨
┃ 2 │ 3 │ 1 ┃ 4 │ 5 │ 6 ┃ 8 │ 9 │ 7 ┃
┠───┼───┼───╂───┼───┼───╂───┼───┼───┨
┃ 5 │ 6 │ 4 ┃ 7 │ 8 │ 9 ┃ 2 │ 3 │ 1 ┃
┣━━━┿━━━┿━━━╋━━━┿━━━┿━━━╋━━━┿━━━┿━━━┫
┃ 6 │ 4 │ 5 ┃ 3 │ 1 │ 2 ┃ 7 │ 8 │ 9 ┃
┠───┼───┼───╂───┼───┼───╂───┼───┼───┨
┃ 9 │ 7 │ 8 ┃ 6 │ 4 │ 5 ┃ 1 │ 2 │ 3 ┃
┠───┼───┼───╂───┼───┼───╂───┼───┼───┨
┃ 3 │ 1 │ 2 ┃ 9 │ 7 │ 8 ┃ 4 │ 5 │ 6 ┃
┗━━━┷━━━┷━━━┻━━━┷━━━┷━━━┻━━━┷━━━┷━━━┛
```

The problem is minor: the program generates correct board anyway.